### PR TITLE
#pragma once を用いて二重include防止するよう変更

### DIFF
--- a/source/continue.h
+++ b/source/continue.h
@@ -2,9 +2,7 @@
 #include "talk.h"
 #include "playerhensuuVr2.h"
 
-#ifndef COUNTINE_H //二重include防止
-
-#define COUNTINE_H
+#pragma once // 二重include防止
 
 void countinuekannsuu() {
 
@@ -199,5 +197,3 @@ void countinuekannsuu2() {
 	//if (talk == 4) { talkdrow2(); countinue = 0; }
 	//キーNを押した場合はtalk.hの関数に飛ぶようにすればいい。
 }
-
-#endif

--- a/source/enemydamegegazou.h
+++ b/source/enemydamegegazou.h
@@ -1,5 +1,4 @@
-#ifndef DEF_enemydamegegazou_H
-#define DEF_enemydamegegazou_H
+#pragma once // 二重include防止
 
 void enemydamegegazou1() {
 
@@ -76,5 +75,3 @@ void enemydamegegazou2() {
 	}
 
 }
-
-#endif

--- a/source/jyuujisuraido.h
+++ b/source/jyuujisuraido.h
@@ -1,11 +1,4 @@
-
-
-#ifndef DEF_jyuujisuraido_H //二重include防止
-
-#define DEF_jyuujisuraido_H
-
-
-
+#pragma once // 二重include防止
 
 void jyuujisuraido() {
 
@@ -268,4 +261,3 @@ void jyuujisuraido() {
 	}
 	
 }
-#endif

--- a/source/kasurikougeki.h
+++ b/source/kasurikougeki.h
@@ -1,8 +1,4 @@
-
-
-#ifndef DEF_kasurikougeki_H //“ñdinclude–h~
-
-#define DEF_kasurikougeki_H
+#pragma once // “ñdinclude–h~
 
 void kasurikougeki() {
 	if (kougekikannkakulock == 0) {
@@ -582,4 +578,3 @@ void kasurikougeki() {
 	//	kougekikannkaku2 = 0;
 	//}
 }
-#endif

--- a/source/key.h
+++ b/source/key.h
@@ -1,10 +1,8 @@
 ﻿#include "DxLib.h"
 
-#ifndef DEF_KEY_H //二重include防止
+#pragma once // 二重include防止
 
-#define DEF_KEY_H
 int Key[256];
-
 
 int gpUpdateKey()
 {
@@ -40,7 +38,3 @@ void UpdatePadState()
 	CurrPadState = GetJoypadInputState(DX_INPUT_KEY_PAD1);  //引数はこれで良いのかな？
 }
 
-
-
-#endif
-#pragma once

--- a/source/orderofcharacters.h
+++ b/source/orderofcharacters.h
@@ -1,10 +1,4 @@
-
-
-
-#ifndef DEF_orderofcharacters_H //“ñdinclude–h~
-
-#define DEF_orderofcharacters_H
-
+#pragma once // “ñdinclude–h~
 
 void orderofcharacters() {
 
@@ -664,5 +658,3 @@ void orderofcharacters() {
 		}
 	}
 }
-
-#endif

--- a/source/playerhensuuVr2.h
+++ b/source/playerhensuuVr2.h
@@ -1,8 +1,6 @@
 ﻿#include "DxLib.h"
 
-#ifndef DEF_PLAYERHENNSUU_H //二重include防止
-
-#define DEF_PLAYERHENNSUU_H
+#pragma once // 二重include防止
 
 int LEFT = 0;
 
@@ -1508,4 +1506,3 @@ int LEFTmark2 = 0;
 int  KATANA3B1[1];
 
 //int lock2 = 0;
-#endif

--- a/source/sennkounyuuryokujyuujiki.h
+++ b/source/sennkounyuuryokujyuujiki.h
@@ -1,8 +1,4 @@
-﻿
-
-#ifndef DEF_SURAIDOKANNSUU_H //二重include防止
-
-#define DEF_SURAIDOKANNSUU_H
+﻿#pragma once // 二重include防止
 
 void suraidoidoukannsuu() {
 
@@ -95,4 +91,3 @@ void suraidoidoukannsuu() {
 
 
 }
-#endif

--- a/source/settoku.h
+++ b/source/settoku.h
@@ -1,11 +1,4 @@
-
-
-#ifndef DEF_settoku_H //“ñdinclude–h~
-
-#define DEF_settoku_H
-
-
-
+#pragma once // “ñdinclude–h~
 
 void settoku1() {
 
@@ -289,9 +282,3 @@ void settoku4() {
 	}
 
 }
-
-
-
-
-
-#endif

--- a/source/settoku2.h
+++ b/source/settoku2.h
@@ -1,8 +1,4 @@
-
-
-#ifndef DEF_settoku2_H //“ñdinclude–h~
-
-#define DEF_settoku2_H
+#pragma once // “ñdinclude–h~
 
 void settoku5() {
 	SetFontSize(16);
@@ -567,6 +563,3 @@ void settoku11() {
 		}
 	}
 }
-
-
-#endif

--- a/source/stage1Player_Draw.h
+++ b/source/stage1Player_Draw.h
@@ -7,9 +7,8 @@
 #include "syuzinnkouKENJYUU.h"
 #include "aruku.h"
 
-#ifndef DEF_STAGE1PLAYER_DRAW_H //二重include防止
+#pragma once // 二重include防止
 
-#define DEF_STAGE1PLAYER_DRAW_H
 //★★ヘッダファイルと関数について。
 //多分、関数stage1PlayerDraw()を呼ぶ際にここにもstage1.hを書くとstage1.hに書いてある関数stage1PlayerDraw()を呼んでしまい、二重になるため、
 //このヘッダファイルにはstage1.hを書くとエラーが出る。それ以外のヘッダファイルは書く意味はないが、もし書いたとしてもエラーにはならないだろう。
@@ -3487,6 +3486,3 @@ void stage1PlayerDraw() {
 
 
 }
-
-
-#endif

--- a/source/stage2Player_Draw.h
+++ b/source/stage2Player_Draw.h
@@ -14,12 +14,8 @@
 #include <vector>
 #include <algorithm>
 
+#pragma once // 二重include防止
 
-
-
-#ifndef DEF_STAGE2PLAYER_DRAW_H //二重include防止
-
-#define DEF_STAGE2PLAYER_DRAW_H
 //★★ヘッダファイルと関数について。
 //多分、関数stage1PlayerDraw()を呼ぶ際にここにもstage1.hを書くとstage1.hに書いてある関数stage1PlayerDraw()を呼んでしまい、二重になるため、
 //このヘッダファイルにはstage1.hを書くとエラーが出る。それ以外のヘッダファイルは書く意味はないが、もし書いたとしてもエラーにはならないだろう。
@@ -4767,7 +4763,3 @@ void stage2PlayerDraw() {
 
 
 }
-
-
-
-#endif

--- a/source/stgae1Player_Update.h
+++ b/source/stgae1Player_Update.h
@@ -5,8 +5,7 @@
 #include "taitol.h"	// !! taitolh.hをtaitol.hに変更しました
 #include "stage1Player_Draw.h"
 
-
-
+#pragma once // 二重include防止
 
 void Player_Update() {
 	//gpUpdateKey();  // キーの入力状態を取得

--- a/source/stgae2Player_Update.h
+++ b/source/stgae2Player_Update.h
@@ -1,5 +1,7 @@
 #include <time.h>
 
+#pragma once // “ñdinclude–h~
+
 void Player_Update2() {
 	//gpUpdateKey();  // ƒL[‚Ì“ü—Íó‘Ô‚ğæ“¾
 	ranndamuBGM = GetRand(4000);

--- a/source/suraidoidoubyouga.h
+++ b/source/suraidoidoubyouga.h
@@ -1,9 +1,4 @@
-
-
-#ifndef DEF_suraidoidoubyouga_H //“ñdinclude–h~
-
-#define DEF_suraidoidoubyouga_H
-
+#pragma once // “ñdinclude–h~
 
 //R1‚ÅƒXƒ‰ƒCƒhˆÚ“®‚·‚é•”•ªB
 void suraidoidoubyouga() {
@@ -317,4 +312,3 @@ void suraidohidariidoubyouga5() {
 		zannzoulock = 0;
 	}
 }
-#endif

--- a/source/syuzinkoukougekigazou.h
+++ b/source/syuzinkoukougekigazou.h
@@ -1,10 +1,4 @@
-
-
-#ifndef DEF_syuzinkoukougekigazou_H //二重include防止
-
-#define DEF_syuzinkoukougekigazou_H
-
-
+#pragma once // 二重include防止
 
 void syuzinkoukougekigazou() {
 	if (playerkonntororulock == 0) {
@@ -713,5 +707,3 @@ void syuzinkoukougekigazou() {
 	//DrawRotaGraph(pos[playerY][playerX][0] + 20 + nanameidouX + migiidou + nanameidouX2 + nanameidouX3 + nanameidouX4 + nanameidouX5, pos[playerY][playerX][1] - 13 + nanameidouY + nanameidouY2 + nanameidouY3 + nanameidouY4 + nanameidouY5, bairituX, 0, playergardGHandle[0], TRUE);
 	//}
 }
-
-#endif

--- a/source/syuzinnkouKENJYUU.h
+++ b/source/syuzinnkouKENJYUU.h
@@ -1,10 +1,4 @@
-
-
-#ifndef DEF_syuzinnkouKENJYUU_H //ìÒèdincludeñhé~
-
-#define DEF_syuzinnkouKENJYUU_H
-
-
+#pragma once // ìÒèdincludeñhé~
 
 void KENJYUU() {
 	//LEFTmark = 44444;
@@ -69,5 +63,3 @@ void KENJYUU() {
 		DrawRotaGraph(pos[playerY][playerX][0] + 20 + nanameidouX + migiidou + nanameidouX2 + nanameidouX3 + nanameidouX4 + nanameidouX5 - 13 + yokeruX, pos[playerY][playerX][1] - 13 + nanameidouY + nanameidouY2 + nanameidouY3 + nanameidouY4 + nanameidouY5, bairituX, 0, playerKENJYUUImage, TRUE);
 	}
 }
-
-#endif

--- a/source/taitol.h
+++ b/source/taitol.h
@@ -1,10 +1,8 @@
 ﻿#include "DxLib.h"
 #include "talk.h"
 #pragma warning(disable: 4996)
+#pragma once // 二重include防止
 
-#ifndef DEF_TAITOLH_H //二重include防止
-
-#define DEF_TAITOLH_H
 int tai = 1;
 int cheak = 0;
 int haikei = 1;
@@ -124,4 +122,3 @@ void taitol() {
 		}
 	}
 }
-#endif

--- a/source/talk.h
+++ b/source/talk.h
@@ -1,13 +1,7 @@
 #include "DxLib.h"
 #include "key.h"
 #pragma warning(disable: 4996)
-
-//#include "taitolh.h"
-#ifndef DEF_talk_H //“ñdinclude–h~
-
-#define DEF_talk_H
-
-
+#pragma once // “ñdinclude–h~
 
 void syokiiti() {
 	int enemyX = 4, enemyY = 1;   // “G‚ÌˆÊ’u
@@ -322,5 +316,3 @@ void talkdrow() {
 	}
 	return;
 }
-
-#endif


### PR DESCRIPTION
\*.h ファイルにおいて、`#ifdef`, `#endif` を用いて二重include防止されていた箇所を `#pragma once` に置き換えてみました。
このようにしますと、\*.hファイルの先頭を確認するだけで、二重include防止されていることが可能になります。
`#endif`書き忘れ防止、多重の`#ifdef`が記載された場合の混乱防止としまして、`#pragma once`をお勧めします。

- Microsoft `#pragma once` に関する説明のWebページ
https://learn.microsoft.com/ja-jp/cpp/preprocessor/once?view=msvc-160

\*.h (ヘッダファイル)の変更内容につきましては、この Conversation タブから一番右にあります Files changed タブをご覧下さい。
問題がないようでしたら、Merge pull request ボタンを押しますと、masterブランチ (@daitovenom 様が作業されているソースコード) に内容が反映されます。

Merge pull requestにつきまして、詳細は以下のWebページをご覧下さいませ。
https://docs.github.com/ja/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request